### PR TITLE
#164273349 Fix admin route

### DIFF
--- a/politico_api/v2/views/users/users_blueprint.py
+++ b/politico_api/v2/views/users/users_blueprint.py
@@ -129,7 +129,7 @@ def change_password():
         "status": error[0], "error": error[1]
     }), error[0])
     
-@users_blueprint_v2.route("/make-admin/<int:user_id>", methods=['PUT'], strict_slashes=False)
+@users_blueprint_v2.route("/promote-user/<int:user_id>", methods=['PUT'], strict_slashes=False)
 @admin_required
 def make_admin(user_id):
     db = request.args.get("db")


### PR DESCRIPTION
### What does this PR do?
Makes the promotion to admin route more understandable by the user consuming the API

### Description of tasks to be completed
- fixes the name of the route '/api/v2/auth/make-admin' to '/api/v2/auth/promote-user'
- update documentation to match this
- update the route on heroku

### What are the relevant PT stories?
<a href="https://www.pivotaltracker.com/story/show/164273349">164273349</a>